### PR TITLE
Update sqlite3

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "grunt-jasmine-node": "~0.2.1"
   },
   "dependencies": {
-    "sqlite3": "~2.2.3",
     "commander": "~2.2.0",
-    "dateformat": "~1.0.8-1.2.3"
+    "dateformat": "~1.0.8-1.2.3",
+    "sqlite3": "~3.0.10"
   },
   "preferGlobal": "true",
   "bin": {


### PR DESCRIPTION
Updating sqlite3 after seeing install issues on Ubuntu.

```
$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 12.04.5 LTS
Release:	12.04
Codename:	precise

$ node --version
v0.12.7

$ npm --version
2.11.3

$ npm install -g ghost-export
npm WARN deprecated set-immediate@0.1.1: Use `setimmediate` instead
-
> sqlite3@2.2.7 install /usr/local/lib/node_modules/ghost-export/node_modules/sqlite3
> node-pre-gyp install --fallback-to-build

[sqlite3] Command failed: /home/recurse/.nvm/versions/node/v0.12.7/bin/node --eval require('/usr/local/lib/node_modules/ghost-export/node_modules/sqlite3/lib/binding/node-v14-linux-x64/node_sqlite3.node')
/home/recurse/.nvm/versions/node/v0.12.7/bin/node: symbol lookup error: /usr/local/lib/node_modules/ghost-export/node_modules/sqlite3/lib/binding/node-v14-linux-x64/node_sqlite3.node: undefined symbol: _ZN2v86Object3SetENS_6HandleINS_5ValueEEES3_NS_17PropertyAttributeE

node-pre-gyp ERR! Testing pre-built binary failed, attempting to source compile
child_process: customFds option is deprecated, use stdio instead.
make: Entering directory `/usr/local/lib/node_modules/ghost-export/node_modules/sqlite3/build'
  ACTION deps_sqlite3_gyp_action_before_build_target_unpack_sqlite_dep Release/obj/gen/sqlite-autoconf-3080500/sqlite3.c
  TOUCH Release/obj.target/deps/action_before_build.stamp
  CC(target) Release/obj.target/sqlite3/gen/sqlite-autoconf-3080500/sqlite3.o
virtual memory exhausted: Cannot allocate memory
make: *** [Release/obj.target/sqlite3/gen/sqlite-autoconf-3080500/sqlite3.o] Error 1
make: Leaving directory `/usr/local/lib/node_modules/ghost-export/node_modules/sqlite3/build'
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/local/lib/node_modules/node-gyp/lib/build.js:269:23)
gyp ERR! stack     at ChildProcess.emit (events.js:110:17)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (child_process.js:1074:12)
gyp ERR! System Linux 3.13.0-32-generic
gyp ERR! command "/home/recurse/.nvm/versions/node/v0.12.7/bin/node" "/usr/local/lib/node_modules/node-gyp/bin/node-gyp.js" "rebuild" "--name=sqlite3" "--configuration=Release" "--module_name=node_sqlite3" "--version=2.2.7" "--major=2" "--minor=2" "--patch=7" "--runtime=node" "--node_abi=node-v14" "--platform=linux" "--target_platform=linux" "--arch=x64" "--target_arch=x64" "--module_main=./lib/sqlite3" "--host=https://mapbox-node-binary.s3.amazonaws.com/" "--module_path=/usr/local/lib/node_modules/ghost-export/node_modules/sqlite3/lib/binding/node-v14-linux-x64" "--remote_path=./sqlite3/v2.2.7/" "--package_name=node-v14-linux-x64.tar.gz" "--staged_tarball=build/stage/sqlite3/v2.2.7/node-v14-linux-x64.tar.gz" "--hosted_path=https://mapbox-node-binary.s3.amazonaws.com/sqlite3/v2.2.7/" "--hosted_tarball=https://mapbox-node-binary.s3.amazonaws.com/sqlite3/v2.2.7/node-v14-linux-x64.tar.gz"
gyp ERR! cwd /usr/local/lib/node_modules/ghost-export/node_modules/sqlite3
gyp ERR! node -v v0.12.7
gyp ERR! node-gyp -v v2.0.2
gyp ERR! not ok
node-pre-gyp ERR! build error
node-pre-gyp ERR! stack Error: Failed to execute '/home/recurse/.nvm/versions/node/v0.12.7/bin/node rebuild --name=sqlite3 --configuration=Release --module_name=node_sqlite3 --version=2.2.7 --major=2 --minor=2 --patch=7 --runtime=node --node_abi=node-v14 --platform=linux --target_platform=linux --arch=x64 --target_arch=x64 --module_main=./lib/sqlite3 --host=https://mapbox-node-binary.s3.amazonaws.com/ --module_path=/usr/local/lib/node_modules/ghost-export/node_modules/sqlite3/lib/binding/node-v14-linux-x64 --remote_path=./sqlite3/v2.2.7/ --package_name=node-v14-linux-x64.tar.gz --staged_tarball=build/stage/sqlite3/v2.2.7/node-v14-linux-x64.tar.gz --hosted_path=https://mapbox-node-binary.s3.amazonaws.com/sqlite3/v2.2.7/ --hosted_tarball=https://mapbox-node-binary.s3.amazonaws.com/sqlite3/v2.2.7/node-v14-linux-x64.tar.gz' (1)
node-pre-gyp ERR! stack     at ChildProcess.<anonymous> (/usr/local/lib/node_modules/ghost-export/node_modules/sqlite3/node_modules/node-pre-gyp/lib/util/compile.js:76:29)
node-pre-gyp ERR! stack     at ChildProcess.emit (events.js:110:17)
node-pre-gyp ERR! stack     at maybeClose (child_process.js:1015:16)
node-pre-gyp ERR! stack     at Process.ChildProcess._handle.onexit (child_process.js:1087:5)
node-pre-gyp ERR! System Linux 3.13.0-32-generic
node-pre-gyp ERR! command "node" "/usr/local/lib/node_modules/ghost-export/node_modules/sqlite3/node_modules/.bin/node-pre-gyp" "install" "--fallback-to-build"
node-pre-gyp ERR! cwd /usr/local/lib/node_modules/ghost-export/node_modules/sqlite3
node-pre-gyp ERR! node -v v0.12.7
node-pre-gyp ERR! node-pre-gyp -v v0.5.22
node-pre-gyp ERR! not ok
Failed to execute '/home/recurse/.nvm/versions/node/v0.12.7/bin/node rebuild --name=sqlite3 --configuration=Release --module_name=node_sqlite3 --version=2.2.7 --major=2 --minor=2 --patch=7 --runtime=node --node_abi=node-v14 --platform=linux --target_platform=linux --arch=x64 --target_arch=x64 --module_main=./lib/sqlite3 --host=https://mapbox-node-binary.s3.amazonaws.com/ --module_path=/usr/local/lib/node_modules/ghost-export/node_modules/sqlite3/lib/binding/node-v14-linux-x64 --remote_path=./sqlite3/v2.2.7/ --package_name=node-v14-linux-x64.tar.gz --staged_tarball=build/stage/sqlite3/v2.2.7/node-v14-linux-x64.tar.gz --hosted_path=https://mapbox-node-binary.s3.amazonaws.com/sqlite3/v2.2.7/ --hosted_tarball=https://mapbox-node-binary.s3.amazonaws.com/sqlite3/v2.2.7/node-v14-linux-x64.tar.gz' (1)
npm ERR! Linux 3.13.0-32-generic
npm ERR! argv "/home/recurse/.nvm/versions/node/v0.12.7/bin/node" "/home/recurse/.nvm/versions/node/v0.12.7/bin/npm" "install" "-g" "ghost-export"
npm ERR! node v0.12.7
npm ERR! npm  v2.11.3
npm ERR! code ELIFECYCLE

npm ERR! sqlite3@2.2.7 install: `node-pre-gyp install --fallback-to-build`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the sqlite3@2.2.7 install script 'node-pre-gyp install --fallback-to-build'.
npm ERR! This is most likely a problem with the sqlite3 package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-pre-gyp install --fallback-to-build
npm ERR! You can get their info via:
npm ERR!     npm owner ls sqlite3
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /usr/local/lib/node_modules/npm-debug.log
```
